### PR TITLE
#51: addEvent should strip sessionId and externalId from posted JSON (closes #51)

### DIFF
--- a/src/main/java/it/contactlab/hub/sdk/java/api/EventApi.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/api/EventApi.java
@@ -27,12 +27,19 @@ public class EventApi {
    * Add a new Event.
    */
   public static Boolean add(Auth auth, Event event) throws HttpException {
-    String endpoint = "/events";
+    final String endpoint = "/events";
     String payload = "";
+
+    JsonObject jsonPayload = (JsonObject) gson.toJsonTree(event);
+
+    // `externalId` and `sessionId` must be wrapped in a `bringBackProperties`
+    // object before being sent to the API.
+    jsonPayload.remove("externalId");
+    jsonPayload.remove("sessionId");
 
     if (event.customerId().isPresent()) {
 
-      payload = gson.toJson(event);
+      payload = jsonPayload.toString();
 
     } else if (event.externalId().isPresent()) {
 
@@ -41,9 +48,7 @@ public class EventApi {
       bringBackProperties.addProperty("value", event.externalId().get());
       bringBackProperties.addProperty("nodeId", auth.nodeId);
 
-      JsonObject jsonPayload = (JsonObject) gson.toJsonTree(event);
       jsonPayload.add("bringBackProperties", bringBackProperties);
-
       payload = jsonPayload.toString();
 
     } else if (event.sessionId().isPresent()) {
@@ -53,9 +58,7 @@ public class EventApi {
       bringBackProperties.addProperty("value", event.sessionId().get());
       bringBackProperties.addProperty("nodeId", auth.nodeId);
 
-      JsonObject jsonPayload = (JsonObject) gson.toJsonTree(event);
       jsonPayload.add("bringBackProperties", bringBackProperties);
-
       payload = jsonPayload.toString();
 
     } else {

--- a/src/test/scala/integration/EventSpec.scala
+++ b/src/test/scala/integration/EventSpec.scala
@@ -83,6 +83,26 @@ class EventSpec extends FeatureSpec with GivenWhenThen {
       Then("the event is created successfully")
       success should be (true)
     }
+
+    scenario("adding an event with sessionId and externalId", Integration) {
+      Given("a new event object with both a sessionId and a externalId")
+      val event = Event.builder
+        .sessionId("ses123")
+        .externalId("ext123")
+        .`type`("viewedPage")
+        .context("WEB")
+        .properties(new JsonObject)
+        .build
+
+      When("the user adds the event")
+      val success = ch.addEvent(event)
+
+      Then("the event is created successfully")
+      success should be (true)
+
+      And("the sessionId is ignored (externalId has precedence)")
+      // FIXME: it's not trivial to test this condition
+    }
   }
 
   feature("retrieving events") {


### PR DESCRIPTION
Issue #51

## Test Plan

### tests performed
* ✅ `sbt test`

### tests not performed (domain coverage)
