### PR TITLE
#53: Remove API tokens from Git (closes #53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,29 +415,8 @@ eventProperties.addProperty("title", "Page Title");
 
 ## Examples
 
-See the [example](example/) folder for working examples that you can download and
+See the [example](example) folder for working examples that you can download and
 try out.
-
-### Running the example with sbt
-
-```sh
-sbt example/run
-```
-
-### Running the example with Gradle
-
-```sh
-cd example
-gradle run
-```
-
-### Running the example with Maven
-
-```sh
-cd example
-mvn compile
-mvn exec:java
-```
 
 ## Contributing to this library
 
@@ -451,6 +430,10 @@ the build tool.
 `sbt doc` will generate an HTML JavaDoc in `target/api`
 
 `sbt packageDoc` will package the javadoc files in a JAR file under `target`
+
+`sbt test` will run the tests. To run the tests you need a valid ContactHub
+account and a test workspace, refer to the notes in the [example](example) to
+set the correct environment variables.
 
 ### Immutables
 

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,52 @@
+# Example
+
+This example project demonstrates how to use the Contacthub Java SDK.
+
+### Auth parameters
+
+To run the example, you need a ContactHub account. From the ContactHub web
+interface, create an API token for a test workspace, then store the token,
+workspace id and node id as environment variables.
+
+**Important:**
+
+Do **NOT** use a production workspace, because running the example will write
+example data (fake Customers and Events) to the workspace you are using.
+
+If you use Linux or macOS:
+
+```sh
+export CONTACTHUB_TEST_TOKEN="..."
+export CONTACTHUB_TEST_WORKSPACE_ID="..."
+export CONTACTHUB_TEST_NODE_ID="..."
+```
+
+If you use Windows:
+
+```dos
+SET "CONTACTHUB_TEST_TOKEN=..."
+SET "CONTACTHUB_TEST_WORKSPACE_ID=..."
+SET "CONTACTHUB_TEST_NODE_ID=..."
+```
+
+### Running the example with sbt
+
+```sh
+sbt example/run
+```
+
+### Running the example with Gradle
+
+```sh
+cd example
+gradle run
+```
+
+### Running the example with Maven
+
+```sh
+cd example
+mvn compile
+mvn exec:java
+```
+


### PR DESCRIPTION
Issue #53

## Test Plan

### tests performed

* all hardcoded auth parameters have been already removed as part of #50, in [this commit](https://github.com/contactlab/contacthub-sdk-java/pull/50/commits/dae293e6cf5d5ced5ae2ec93d45f66e6fab09a6b).
* the token that was hardcoded has been disabled from the ContactHub web interface and is not valid anymore
* this pull request only adds some documentation about what env vars should be set

### tests not performed (domain coverage)
