### PR TITLE
#63: Allow custom API url (closes #63)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,19 @@ Auth auth = new Auth(token, workspaceId, nodeId);
 ContactHub ch = new ContactHub(auth);
 ```
 
+### Custom API url
+
+If you want to use a non-standard baseUrl for the API (for example to connect to
+a staging environment), you can add the API base URL as an optional parameter:
+
+
+```java
+Auth auth = new Auth(token, workspaceId, nodeId, apiUrl);
+```
+
+If not specified, the SDK will use the default URL for the Contacthub API:
+https://api.contactlab.it/hub/v1
+
 ## Session API
 
 ### createSessionId

--- a/src/main/java/it/contactlab/hub/sdk/java/Auth.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/Auth.java
@@ -6,9 +6,12 @@ package it.contactlab.hub.sdk.java;
  */
 public class Auth {
 
+  private static final String DEFAULT_API_URL = "https://api.contactlab.it/hub/v1";
+
   public final String token;
   public final String workspaceId;
   public final String nodeId;
+  public final String apiUrl;
 
   /**
    * Creates a new Auth instance.
@@ -17,10 +20,32 @@ public class Auth {
    * @param workspaceId The workspace id.
    * @param nodeId      The node id.
    */
-  public Auth(String token, String workspaceId, String nodeId) {
+  public Auth(
+      String token,
+      String workspaceId,
+      String nodeId
+  ) {
+    this(token, workspaceId, nodeId, DEFAULT_API_URL);
+  }
+
+  /**
+   * Creates a new Auth instance with a custom API url.
+   *
+   * @param token       The authorization token.
+   * @param workspaceId The workspace id.
+   * @param nodeId      The node id.
+   * @param apiUrl      The API url.
+   */
+  public Auth(
+      String token,
+      String workspaceId,
+      String nodeId,
+      String apiUrl
+  ) {
     this.token = token;
     this.workspaceId = workspaceId;
     this.nodeId = nodeId;
+    this.apiUrl = apiUrl;
   }
 
 }

--- a/src/main/java/it/contactlab/hub/sdk/java/internal/http/Request.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/internal/http/Request.java
@@ -10,15 +10,13 @@ import org.json.JSONObject;
 
 public class Request {
 
-  private static String baseUrl = "https://api.contactlab.it/hub/v1";
-
   /**
    * Sends a generic GET request and returns the response JsonObject.
    */
   public static JSONObject doGet(Auth auth, String endpoint) throws HttpException {
     try {
       Unirest.setDefaultHeader("Authorization", "Bearer " + auth.token);
-      String url = baseUrl + "/workspaces/" + auth.workspaceId + endpoint;
+      String url = auth.apiUrl + "/workspaces/" + auth.workspaceId + endpoint;
 
       HttpResponse<JsonNode> response = Unirest.get(url).asJson();
 
@@ -43,7 +41,7 @@ public class Request {
       throws HttpException {
     try {
       Unirest.setDefaultHeader("Authorization", "Bearer " + auth.token);
-      String url = baseUrl + "/workspaces/" + auth.workspaceId + endpoint;
+      String url = auth.apiUrl + "/workspaces/" + auth.workspaceId + endpoint;
 
       HttpResponse<JsonNode> response = Unirest
           .post(url)
@@ -71,7 +69,7 @@ public class Request {
   public static JSONObject doDelete(Auth auth, String endpoint) throws HttpException {
     try {
       Unirest.setDefaultHeader("Authorization", "Bearer " + auth.token);
-      String url = baseUrl + "/workspaces/" + auth.workspaceId + endpoint;
+      String url = auth.apiUrl + "/workspaces/" + auth.workspaceId + endpoint;
 
       HttpResponse<JsonNode> response = Unirest.delete(url).asJson();
 
@@ -95,7 +93,7 @@ public class Request {
   public static JSONObject doPut(Auth auth, String endpoint, String payload) throws HttpException {
     try {
       Unirest.setDefaultHeader("Authorization", "Bearer " + auth.token);
-      String url = baseUrl + "/workspaces/" + auth.workspaceId + endpoint;
+      String url = auth.apiUrl + "/workspaces/" + auth.workspaceId + endpoint;
 
       HttpResponse<JsonNode> response = Unirest
           .put(url)
@@ -124,7 +122,7 @@ public class Request {
       throws HttpException {
     try {
       Unirest.setDefaultHeader("Authorization", "Bearer " + auth.token);
-      String url = baseUrl + "/workspaces/" + auth.workspaceId + endpoint;
+      String url = auth.apiUrl + "/workspaces/" + auth.workspaceId + endpoint;
 
       HttpResponse<JsonNode> response = Unirest
           .patch(url)


### PR DESCRIPTION
Closes #63

## Test Plan

### tests performed
* `sbt test`
* `sbt example/run`

### tests not performed (domain coverage)
* I haven't added any new tests for this feature. I would need to mock the `Unirest` library and the effort did not seem justified for a non-critical feature.