### PR TITLE
#90: Model for contextInfo (closes #90)

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,27 +430,32 @@ See [Pagination](#pagination).
 
 ### addEvent
 
-Add a new Event. The API will process the event queue asynchronously, and it can
+To create an `Event` instance, use the builder provided by one the `Event` subtypes object.
+Currently there are 9 `Event` subtypes, that are characterized by their context: they are
+`ContactCenterEvent`,`DigitalCampaignEvent`,`EcommerceEvent`,`IotEvent`,`MobileEvent`,`OtherEvent`,
+`RetailEvent`,`SocialEvent` and `WebEvent`.
+
+
+```java
+event = WebEvent.builder()
+          .customerId(customerId)
+          .type(EventType.viewedPage)
+          .properties(eventProperties)
+          .build();
+```
+
+As `Event` subtypes are characterized by their context, you should not specify it in the builder.
+The type of `eventProperties` must be a subtype of `AbstractContextInfo`, and each `Event` subtype specifies
+its `AbstractContextInfo` subtype. Please check the Javadoc at http://javadoc.io/doc/com.contactlab.hub/sdk-java/
+if you need further information.
+When your event is built, you can add it using the following method:
+
+```java
+queued = ch.addEvent((Event) event)
+```
+
+The API will process the event queue asynchronously, and it can
 take a few seconds for an event to be actually stored.
-
-```java
-queued = ch.addEvent(event)
-```
-
-To create an `Event` instance, use the builder provided by the `Event` object.
-
-```java
-Event.builder()
-  .customerId(customerId)
-  .context(EventContext.WEB)
-  .type(EventType.viewedPage)
-  .properties(eventProperties)
-  .build();
-```
-
-`eventProperties` must be of type `Map<String, Object>`. The
-structure of this object varies according to the event type, and always contains
-a number of optional fields. You should only include the properties that you need.
 
 **Example:**
 

--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ if you need further information.
 When your event is built, you can add it using the following method:
 
 ```java
-queued = ch.addEvent((Event) event)
+queued = ch.addEvent(event)
 ```
 
 The API will process the event queue asynchronously, and it can

--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,7 @@ lazy val testDependencies = Seq(
 lazy val dependencies = Seq(
   "org.immutables" % "value" % "2.3.7",
   "com.mashape.unirest" % "unirest-java" % "1.4.9",
-  "com.google.code.gson" % "gson" % "2.7",
+  "com.google.code.gson" % "gson" % "2.8.4",
   "com.google.code.findbugs" % "jsr305" % "3.0.0"
 )
 

--- a/src/main/java/it/contactlab/hub/sdk/java/ContactHub.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/ContactHub.java
@@ -17,7 +17,6 @@ import it.contactlab.hub.sdk.java.models.Event;
 import it.contactlab.hub.sdk.java.models.EventFilters;
 import it.contactlab.hub.sdk.java.models.GetCustomersOptions;
 import it.contactlab.hub.sdk.java.models.ClientData;
-import it.contactlab.hub.sdk.java.models.ContactCenterEvent;
 import it.contactlab.hub.sdk.java.models.Job;
 import it.contactlab.hub.sdk.java.models.Like;
 import it.contactlab.hub.sdk.java.models.Paginated;

--- a/src/main/java/it/contactlab/hub/sdk/java/ContactHub.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/ContactHub.java
@@ -17,6 +17,7 @@ import it.contactlab.hub.sdk.java.models.Event;
 import it.contactlab.hub.sdk.java.models.EventFilters;
 import it.contactlab.hub.sdk.java.models.GetCustomersOptions;
 import it.contactlab.hub.sdk.java.models.ClientData;
+import it.contactlab.hub.sdk.java.models.ContactCenterEvent;
 import it.contactlab.hub.sdk.java.models.Job;
 import it.contactlab.hub.sdk.java.models.Like;
 import it.contactlab.hub.sdk.java.models.Paginated;

--- a/src/main/java/it/contactlab/hub/sdk/java/internal/api/EventApi.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/internal/api/EventApi.java
@@ -2,6 +2,9 @@ package it.contactlab.hub.sdk.java.internal.api;
 
 import it.contactlab.hub.sdk.java.Auth;
 import it.contactlab.hub.sdk.java.models.ClientData;
+import it.contactlab.hub.sdk.java.models.ContactCenterEvent;
+import it.contactlab.hub.sdk.java.models.DigitalCampaignEvent;
+import it.contactlab.hub.sdk.java.models.EcommerceEvent;
 import it.contactlab.hub.sdk.java.exceptions.ApiException;
 import it.contactlab.hub.sdk.java.exceptions.ContactHubException;
 import it.contactlab.hub.sdk.java.exceptions.HttpException;
@@ -10,9 +13,16 @@ import it.contactlab.hub.sdk.java.internal.gson.ContactHubGson;
 import it.contactlab.hub.sdk.java.internal.http.Request;
 import it.contactlab.hub.sdk.java.models.AsyncPaginated;
 import it.contactlab.hub.sdk.java.models.Event;
+import it.contactlab.hub.sdk.java.models.EventContext;
 import it.contactlab.hub.sdk.java.models.EventFilters;
+import it.contactlab.hub.sdk.java.models.IotEvent;
+import it.contactlab.hub.sdk.java.models.MobileEvent;
+import it.contactlab.hub.sdk.java.models.OtherEvent;
 import it.contactlab.hub.sdk.java.models.Paged;
 import it.contactlab.hub.sdk.java.models.Paginated;
+import it.contactlab.hub.sdk.java.models.RetailEvent;
+import it.contactlab.hub.sdk.java.models.SocialEvent;
+import it.contactlab.hub.sdk.java.models.WebEvent;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -157,7 +167,7 @@ public class EventApi {
 
   /**
    * Retrieves an Event by id.
- * @param clientData 
+ * @param clientData
    */
   public static Event getById(Auth auth, ClientData clientData, String id)
       throws ApiException, ServerException, HttpException {

--- a/src/main/java/it/contactlab/hub/sdk/java/internal/gson/ContactHubGson.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/internal/gson/ContactHubGson.java
@@ -6,6 +6,17 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializer;
 
+import it.contactlab.hub.sdk.java.models.ContactCenterEvent;
+import it.contactlab.hub.sdk.java.models.DigitalCampaignEvent;
+import it.contactlab.hub.sdk.java.models.EcommerceEvent;
+import it.contactlab.hub.sdk.java.models.Event;
+import it.contactlab.hub.sdk.java.models.EventContext;
+import it.contactlab.hub.sdk.java.models.MobileEvent;
+import it.contactlab.hub.sdk.java.models.OtherEvent;
+import it.contactlab.hub.sdk.java.models.RetailEvent;
+import it.contactlab.hub.sdk.java.models.SocialEvent;
+import it.contactlab.hub.sdk.java.models.WebEvent;
+
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -50,13 +61,27 @@ public class ContactHubGson {
    * Registering all (de)serializers.
    */
   public static final Gson getInstance() {
+
+    RuntimeTypeAdapterFactory<Event> eventAdapter =
+        RuntimeTypeAdapterFactory
+        .of(Event.class, "context")
+        .registerSubtype(ContactCenterEvent.class, EventContext.CONTACT_CENTER.toString())
+        .registerSubtype(DigitalCampaignEvent.class, EventContext.DIGITAL_CAMPAIGN.toString())
+        .registerSubtype(EcommerceEvent.class, EventContext.ECOMMERCE.toString())
+        .registerSubtype(MobileEvent.class, EventContext.MOBILE.toString())
+        .registerSubtype(OtherEvent.class, EventContext.OTHER.toString())
+        .registerSubtype(RetailEvent.class, EventContext.RETAIL.toString())
+        .registerSubtype(SocialEvent.class, EventContext.SOCIAL.toString())
+        .registerSubtype(WebEvent.class, EventContext.WEB.toString());
+
     GsonBuilder gsonBuilder = new GsonBuilder()
         .registerTypeAdapter(OffsetDateTime.class, dateTimeJsonDeserializer)
         .registerTypeAdapter(OffsetDateTime.class, dateTimeJsonSerializer)
         .registerTypeAdapter(LocalDate.class, dateJsonSerializer)
         .registerTypeAdapter(LocalDate.class, dateJsonDeserializer)
         .registerTypeAdapter(ZoneId.class, zoneIdJsonSerializer)
-        .registerTypeAdapter(ZoneId.class, zoneIdJsonDeserializer);
+        .registerTypeAdapter(ZoneId.class, zoneIdJsonDeserializer)
+        .registerTypeAdapterFactory(eventAdapter);
 
     return gsonBuilder.create();
   }

--- a/src/main/java/it/contactlab/hub/sdk/java/internal/gson/RuntimeTypeAdapterFactory.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/internal/gson/RuntimeTypeAdapterFactory.java
@@ -1,0 +1,113 @@
+package it.contactlab.hub.sdk.java.internal.gson;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.internal.Streams;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
+  private final Class<?> baseType;
+  private final String typeFieldName;
+  private final Map<String, Class<?>> labelToSubtype = new LinkedHashMap<String, Class<?>>();
+  private final Map<Class<?>, String> subtypeToLabel = new LinkedHashMap<Class<?>, String>();
+
+  private RuntimeTypeAdapterFactory(Class<?> baseType, String typeFieldName) {
+    if (typeFieldName == null || baseType == null) {
+      throw new NullPointerException();
+    }
+    this.baseType = baseType;
+    this.typeFieldName = typeFieldName;
+  }
+
+  public static <T> RuntimeTypeAdapterFactory<T> of(Class<T> baseType, String typeFieldName) {
+    return new RuntimeTypeAdapterFactory<T>(baseType, typeFieldName);
+  }
+
+  public static <T> RuntimeTypeAdapterFactory<T> of(Class<T> baseType) {
+    return new RuntimeTypeAdapterFactory<T>(baseType, "type");
+  }
+
+  public RuntimeTypeAdapterFactory<T> registerSubtype(Class<? extends T> type, String label) {
+    if (type == null || label == null) {
+      throw new NullPointerException();
+    }
+    if (subtypeToLabel.containsKey(type) || labelToSubtype.containsKey(label)) {
+      throw new IllegalArgumentException("types and labels must be unique");
+    }
+    labelToSubtype.put(label, type);
+    subtypeToLabel.put(type, label);
+    return this;
+  }
+
+  public RuntimeTypeAdapterFactory<T> registerSubtype(Class<? extends T> type) {
+    return registerSubtype(type, type.getSimpleName());
+  }
+
+  public <R> TypeAdapter<R> create(Gson gson, TypeToken<R> type) {
+    if (type.getRawType() != baseType) {
+      return null;
+    }
+
+    final Map<String, TypeAdapter<?>> labelToDelegate
+        = new LinkedHashMap<String, TypeAdapter<?>>();
+    final Map<Class<?>, TypeAdapter<?>> subtypeToDelegate
+        = new LinkedHashMap<Class<?>, TypeAdapter<?>>();
+    for (Map.Entry<String, Class<?>> entry : labelToSubtype.entrySet()) {
+      TypeAdapter<?> delegate = gson.getDelegateAdapter(this, TypeToken.get(entry.getValue()));
+      labelToDelegate.put(entry.getKey(), delegate);
+      subtypeToDelegate.put(entry.getValue(), delegate);
+    }
+
+    return new TypeAdapter<R>() {
+      @Override public R read(JsonReader in) throws IOException {
+        JsonElement jsonElement = Streams.parse(in);
+        JsonElement labelJsonElement = jsonElement.getAsJsonObject().get(typeFieldName);
+        if (labelJsonElement == null) {
+          throw new JsonParseException("cannot deserialize " + baseType
+              + " because it does not define a field named " + typeFieldName);
+        }
+        String label = labelJsonElement.getAsString();
+        @SuppressWarnings("unchecked") // registration requires that subtype extends T
+        TypeAdapter<R> delegate = (TypeAdapter<R>) labelToDelegate.get(label);
+        if (delegate == null) {
+          throw new JsonParseException("cannot deserialize " + baseType + " subtype named "
+              + label + "; did you forget to register a subtype?");
+        }
+        return delegate.fromJsonTree(jsonElement);
+      }
+
+      @Override public void write(JsonWriter out, R value) throws IOException {
+        Class<?> srcType = value.getClass();
+        String label = subtypeToLabel.get(srcType);
+        @SuppressWarnings("unchecked") // registration requires that subtype extends T
+        TypeAdapter<R> delegate = (TypeAdapter<R>) subtypeToDelegate.get(srcType);
+        if (delegate == null) {
+          throw new JsonParseException("cannot serialize " + srcType.getName()
+              + "; did you forget to register a subtype?");
+        }
+        JsonObject jsonObject = delegate.toJsonTree(value).getAsJsonObject();
+        if (jsonObject.has(typeFieldName)) {
+          throw new JsonParseException("cannot serialize " + srcType.getName()
+              + " because it already defines a field named " + typeFieldName);
+        }
+        JsonObject clone = new JsonObject();
+        clone.add(typeFieldName, new JsonPrimitive(label));
+        for (Map.Entry<String, JsonElement> e : jsonObject.entrySet()) {
+          clone.add(e.getKey(), e.getValue());
+        }
+        Streams.write(clone, out);
+      }
+    }.nullSafe();
+  }
+}

--- a/src/main/java/it/contactlab/hub/sdk/java/internal/gson/RuntimeTypeAdapterFactory.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/internal/gson/RuntimeTypeAdapterFactory.java
@@ -16,6 +16,10 @@ import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 
+/**
+ * Factory for RuntimeTypeAdapters, based on
+ * https://github.com/google/gson/blob/master/extras/src/main/java/com/google/gson/typeadapters/RuntimeTypeAdapterFactory.java
+ */
 public final class RuntimeTypeAdapterFactory<T> implements TypeAdapterFactory {
   private final Class<?> baseType;
   private final String typeFieldName;

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractClient.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractClient.java
@@ -1,0 +1,28 @@
+package it.contactlab.hub.sdk.java.models;
+
+import org.immutables.value.Value;
+
+import java.util.Optional;
+
+/**
+ * Details about the client in an event context info.
+ */
+@Value.Immutable
+@Value.Style(typeImmutable = "*")
+public abstract class AbstractClient {
+
+  /**
+   * The user agent of the client.
+   */
+  public abstract Optional<String> userAgent();
+
+  /**
+   * The ipv4 of the client.
+   */
+  public abstract String ip();
+
+  /**
+   * The localization of the client.
+   */
+  public abstract Optional<Localization> localization();
+}

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractContactCenterContextInfo.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractContactCenterContextInfo.java
@@ -1,0 +1,21 @@
+package it.contactlab.hub.sdk.java.models;
+
+import org.immutables.value.Value;
+
+/**
+ * Events made in contact center context.
+ */
+@Value.Immutable
+@Value.Style(typeImmutable = "*")
+public abstract class AbstractContactCenterContextInfo {
+
+  /**
+   * The client of this Event context info.
+   */
+  public abstract Client client();
+
+  /**
+   * The user for this Event context info.
+   */
+  public abstract User user();
+}

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractContactCenterContextInfo.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractContactCenterContextInfo.java
@@ -7,15 +7,5 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @Value.Style(typeImmutable = "*")
-public abstract class AbstractContactCenterContextInfo {
-
-  /**
-   * The client of this Event context info.
-   */
-  public abstract Client client();
-
-  /**
-   * The user for this Event context info.
-   */
-  public abstract User user();
+public abstract class AbstractContactCenterContextInfo extends AbstractContextInfo {
 }

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractContactCenterEvent.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractContactCenterEvent.java
@@ -11,7 +11,7 @@ import java.util.Optional;
  */
 @Value.Immutable
 @Value.Style(typeImmutable = "*")
-public abstract class AbstractContactCenterEvent extends AbstractEvent {
+public abstract class AbstractContactCenterEvent extends Event {
 
   /**
    * The ID of this Event.
@@ -41,6 +41,7 @@ public abstract class AbstractContactCenterEvent extends AbstractEvent {
   /**
    * The event context of this Event.
    */
+  @Value.Derived
   public EventContext context() {
     return EventContext.CONTACT_CENTER;
   }
@@ -54,7 +55,7 @@ public abstract class AbstractContactCenterEvent extends AbstractEvent {
    * The context-specific properties of this Event.
    */
   @Override
-  public abstract ContactCenterContextInfo contextInfo();
+  public abstract Optional<ContactCenterContextInfo> contextInfo();
 
   /**
    * The moment when this Event happened.

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractContactCenterEvent.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractContactCenterEvent.java
@@ -1,0 +1,73 @@
+package it.contactlab.hub.sdk.java.models;
+
+import org.immutables.value.Value;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * An Event made in the context of a contact center.
+ */
+@Value.Immutable
+@Value.Style(typeImmutable = "*")
+public abstract class AbstractContactCenterEvent extends AbstractEvent {
+
+  /**
+   * The ID of this Event.
+   */
+  public abstract Optional<String> id();
+
+  /**
+   * The CustomerId for this Event.
+   */
+  public abstract Optional<String> customerId();
+
+  /**
+   * The ExternalId for this Event.
+   */
+  public abstract Optional<String> externalId();
+
+  /**
+   * The SessionId for this Event.
+   */
+  public abstract Optional<String> sessionId();
+
+  /**
+   * The event type of this Event.
+   */
+  public abstract EventType type();
+
+  /**
+   * The event context of this Event.
+   */
+  public EventContext context() {
+    return EventContext.CONTACT_CENTER;
+  }
+
+  /**
+   * The properties of this Event.
+   */
+  public abstract Map<String, Object> properties();
+
+  /**
+   * The context-specific properties of this Event.
+   */
+  @Override
+  public abstract ContactCenterContextInfo contextInfo();
+
+  /**
+   * The moment when this Event happened.
+   *
+   * <p>It defaults to "now()" if not specified when creating a new Event.</p>
+   */
+  @Value.Default
+  public OffsetDateTime date() {
+    return OffsetDateTime.now();
+  }
+
+  /**
+   * The moment when this Event was registered.
+   */
+  public abstract Optional<OffsetDateTime> registeredAt();
+}

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractContextInfo.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractContextInfo.java
@@ -1,0 +1,19 @@
+package it.contactlab.hub.sdk.java.models;
+
+import org.immutables.value.Value;
+
+/**
+ * Context info about an Event.
+ */
+public abstract class AbstractContextInfo {
+
+  /**
+   * The client of this Event context info.
+   */
+  public abstract Client client();
+
+  /**
+   * The user for this Event context info.
+   */
+  public abstract User user();
+}

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractDevice.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractDevice.java
@@ -1,0 +1,56 @@
+package it.contactlab.hub.sdk.java.models;
+
+import org.immutables.value.Value;
+
+/**
+ *  Device of mobile context info.
+ */
+@Value.Immutable
+@Value.Style(typeImmutable = "*")
+public abstract class AbstractDevice {
+
+  /**
+   * The bundle identifier of the mobile device.
+   */
+  public abstract String bundleIdentifier();
+
+  /**
+   * The version number of the mobile device.
+   */
+  public abstract String versionNumber();
+
+  /**
+   * The build number of the mobile device.
+   */
+  public abstract String buildNumber();
+
+  /**
+   * The vendor indentifier of the mobile device.
+   */
+  public abstract String identifierForVendor();
+
+  /**
+   * The system version of the mobile device.
+   */
+  public abstract String systemVersion();
+
+  /**
+   * The model of the mobile device.
+   */
+  public abstract String model();
+
+  /**
+   * The device vendor of the mobile device.
+   */
+  public abstract String deviceVendor();
+
+  /**
+   * The locale of the mobile device.
+   */
+  public abstract String locale();
+
+  /**
+   * The language of the mobile device.
+   */
+  public abstract String language();
+}

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractDigitalCampaignContextInfo.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractDigitalCampaignContextInfo.java
@@ -1,0 +1,21 @@
+package it.contactlab.hub.sdk.java.models;
+
+import org.immutables.value.Value;
+
+/**
+ * Context info about events made in digital message context, like email marketing, sms, push, etc..
+ */
+@Value.Immutable
+@Value.Style(typeImmutable = "*")
+public abstract class AbstractDigitalCampaignContextInfo {
+
+  /**
+   * The client of this Event context info.
+   */
+  public abstract Client client();
+
+  /**
+   * The user for this Event context info.
+   */
+  public abstract User user();
+}

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractDigitalCampaignContextInfo.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractDigitalCampaignContextInfo.java
@@ -7,15 +7,5 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @Value.Style(typeImmutable = "*")
-public abstract class AbstractDigitalCampaignContextInfo {
-
-  /**
-   * The client of this Event context info.
-   */
-  public abstract Client client();
-
-  /**
-   * The user for this Event context info.
-   */
-  public abstract User user();
+public abstract class AbstractDigitalCampaignContextInfo extends AbstractContextInfo{
 }

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractDigitalCampaignEvent.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractDigitalCampaignEvent.java
@@ -11,7 +11,7 @@ import java.util.Optional;
  */
 @Value.Immutable
 @Value.Style(typeImmutable = "*")
-public abstract class AbstractContactCenterEvent extends AbstractEvent {
+public abstract class AbstractDigitalCampaignEvent extends AbstractEvent {
 
   /**
    * The ID of this Event.

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractDigitalCampaignEvent.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractDigitalCampaignEvent.java
@@ -1,0 +1,73 @@
+package it.contactlab.hub.sdk.java.models;
+
+import org.immutables.value.Value;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * An Event made in the context of a digital campaign.
+ */
+@Value.Immutable
+@Value.Style(typeImmutable = "*")
+public abstract class AbstractContactCenterEvent extends AbstractEvent {
+
+  /**
+   * The ID of this Event.
+   */
+  public abstract Optional<String> id();
+
+  /**
+   * The CustomerId for this Event.
+   */
+  public abstract Optional<String> customerId();
+
+  /**
+   * The ExternalId for this Event.
+   */
+  public abstract Optional<String> externalId();
+
+  /**
+   * The SessionId for this Event.
+   */
+  public abstract Optional<String> sessionId();
+
+  /**
+   * The event type of this Event.
+   */
+  public abstract EventType type();
+
+  /**
+   * The event context of this Event.
+   */
+  public EventContext context() {
+    return EventContext.DIGITAL_CAMPAIGN;
+  }
+
+  /**
+   * The properties of this Event.
+   */
+  public abstract Map<String, Object> properties();
+
+  /**
+   * The context-specific properties of this Event.
+   */
+  @Override
+  public abstract DigitalCampaignContextInfo contextInfo();
+
+  /**
+   * The moment when this Event happened.
+   *
+   * <p>It defaults to "now()" if not specified when creating a new Event.</p>
+   */
+  @Value.Default
+  public OffsetDateTime date() {
+    return OffsetDateTime.now();
+  }
+
+  /**
+   * The moment when this Event was registered.
+   */
+  public abstract Optional<OffsetDateTime> registeredAt();
+}

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractDigitalCampaignEvent.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractDigitalCampaignEvent.java
@@ -11,7 +11,7 @@ import java.util.Optional;
  */
 @Value.Immutable
 @Value.Style(typeImmutable = "*")
-public abstract class AbstractDigitalCampaignEvent extends AbstractEvent {
+public abstract class AbstractDigitalCampaignEvent extends Event {
 
   /**
    * The ID of this Event.
@@ -41,6 +41,7 @@ public abstract class AbstractDigitalCampaignEvent extends AbstractEvent {
   /**
    * The event context of this Event.
    */
+  @Value.Derived
   public EventContext context() {
     return EventContext.DIGITAL_CAMPAIGN;
   }
@@ -54,7 +55,7 @@ public abstract class AbstractDigitalCampaignEvent extends AbstractEvent {
    * The context-specific properties of this Event.
    */
   @Override
-  public abstract DigitalCampaignContextInfo contextInfo();
+  public abstract Optional<DigitalCampaignContextInfo> contextInfo();
 
   /**
    * The moment when this Event happened.

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractEcommerceContextInfo.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractEcommerceContextInfo.java
@@ -1,0 +1,26 @@
+package it.contactlab.hub.sdk.java.models;
+
+import org.immutables.value.Value;
+
+/**
+ * Context info about events made in e-commerce context.
+ */
+@Value.Immutable
+@Value.Style(typeImmutable = "*")
+public abstract class AbstractEcommerceContextInfo {
+
+  /**
+   * The client of this Event context info.
+   */
+  public abstract Client client();
+
+  /**
+   * The store for this Event context info.
+   */
+  public abstract Store store();
+
+  /**
+   * The user for this Event context info.
+   */
+  public abstract User user();
+}

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractEcommerceContextInfo.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractEcommerceContextInfo.java
@@ -7,20 +7,9 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @Value.Style(typeImmutable = "*")
-public abstract class AbstractEcommerceContextInfo {
-
-  /**
-   * The client of this Event context info.
-   */
-  public abstract Client client();
-
+public abstract class AbstractEcommerceContextInfo extends AbstractContextInfo{
   /**
    * The store for this Event context info.
    */
   public abstract Store store();
-
-  /**
-   * The user for this Event context info.
-   */
-  public abstract User user();
 }

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractEcommerceEvent.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractEcommerceEvent.java
@@ -1,0 +1,73 @@
+package it.contactlab.hub.sdk.java.models;
+
+import org.immutables.value.Value;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * An Event made in e-commerce context.
+ */
+@Value.Immutable
+@Value.Style(typeImmutable = "*")
+public abstract class AbstractEcommerceEvent extends AbstractEvent {
+
+  /**
+   * The ID of this Event.
+   */
+  public abstract Optional<String> id();
+
+  /**
+   * The CustomerId for this Event.
+   */
+  public abstract Optional<String> customerId();
+
+  /**
+   * The ExternalId for this Event.
+   */
+  public abstract Optional<String> externalId();
+
+  /**
+   * The SessionId for this Event.
+   */
+  public abstract Optional<String> sessionId();
+
+  /**
+   * The event type of this Event.
+   */
+  public abstract EventType type();
+
+  /**
+   * The event context of this Event.
+   */
+  public EventContext context() {
+    return EventContext.ECOMMERCE;
+  }
+
+  /**
+   * The properties of this Event.
+   */
+  public abstract Map<String, Object> properties();
+
+  /**
+   * The context-specific properties of this Event.
+   */
+  @Override
+  public abstract EcommerceContextInfo contextInfo();
+
+  /**
+   * The moment when this Event happened.
+   *
+   * <p>It defaults to "now()" if not specified when creating a new Event.</p>
+   */
+  @Value.Default
+  public OffsetDateTime date() {
+    return OffsetDateTime.now();
+  }
+
+  /**
+   * The moment when this Event was registered.
+   */
+  public abstract Optional<OffsetDateTime> registeredAt();
+}

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractEcommerceEvent.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractEcommerceEvent.java
@@ -11,7 +11,7 @@ import java.util.Optional;
  */
 @Value.Immutable
 @Value.Style(typeImmutable = "*")
-public abstract class AbstractEcommerceEvent extends AbstractEvent {
+public abstract class AbstractEcommerceEvent extends Event {
 
   /**
    * The ID of this Event.
@@ -41,6 +41,7 @@ public abstract class AbstractEcommerceEvent extends AbstractEvent {
   /**
    * The event context of this Event.
    */
+  @Value.Derived
   public EventContext context() {
     return EventContext.ECOMMERCE;
   }
@@ -54,7 +55,7 @@ public abstract class AbstractEcommerceEvent extends AbstractEvent {
    * The context-specific properties of this Event.
    */
   @Override
-  public abstract EcommerceContextInfo contextInfo();
+  public abstract Optional<EcommerceContextInfo> contextInfo();
 
   /**
    * The moment when this Event happened.

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractIotContextInfo.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractIotContextInfo.java
@@ -7,15 +7,5 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @Value.Style(typeImmutable = "*")
-public abstract class AbstractIotContextInfo {
-
-  /**
-   * The client of this Event context info.
-   */
-  public abstract Client client();
-
-  /**
-   * The user for this Event context info.
-   */
-  public abstract User user();
+public abstract class AbstractIotContextInfo extends AbstractContextInfo{
 }

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractIotContextInfo.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractIotContextInfo.java
@@ -7,7 +7,7 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @Value.Style(typeImmutable = "*")
-public abstract class AbstractEcommerceContextInfo {
+public abstract class AbstractIotContextInfo {
 
   /**
    * The client of this Event context info.

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractIotContextInfo.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractIotContextInfo.java
@@ -1,0 +1,21 @@
+package it.contactlab.hub.sdk.java.models;
+
+import org.immutables.value.Value;
+
+/**
+ * Context info about events made in internet of things context.
+ */
+@Value.Immutable
+@Value.Style(typeImmutable = "*")
+public abstract class AbstractEcommerceContextInfo {
+
+  /**
+   * The client of this Event context info.
+   */
+  public abstract Client client();
+
+  /**
+   * The user for this Event context info.
+   */
+  public abstract User user();
+}

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractIotEvent.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractIotEvent.java
@@ -11,7 +11,7 @@ import java.util.Optional;
  */
 @Value.Immutable
 @Value.Style(typeImmutable = "*")
-public abstract class AbstractIotEvent extends AbstractEvent {
+public abstract class AbstractIotEvent extends Event {
 
   /**
    * The ID of this Event.
@@ -41,6 +41,7 @@ public abstract class AbstractIotEvent extends AbstractEvent {
   /**
    * The event context of this Event.
    */
+  @Value.Derived
   public EventContext context() {
     return EventContext.IOT;
   }
@@ -54,7 +55,7 @@ public abstract class AbstractIotEvent extends AbstractEvent {
    * The context-specific properties of this Event.
    */
   @Override
-  public abstract IotContextInfo contextInfo();
+  public abstract Optional<IotContextInfo> contextInfo();
 
   /**
    * The moment when this Event happened.

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractIotEvent.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractIotEvent.java
@@ -1,0 +1,73 @@
+package it.contactlab.hub.sdk.java.models;
+
+import org.immutables.value.Value;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * An Event made in Internet of Things context.
+ */
+@Value.Immutable
+@Value.Style(typeImmutable = "*")
+public abstract class AbstractIotEvent extends AbstractEvent {
+
+  /**
+   * The ID of this Event.
+   */
+  public abstract Optional<String> id();
+
+  /**
+   * The CustomerId for this Event.
+   */
+  public abstract Optional<String> customerId();
+
+  /**
+   * The ExternalId for this Event.
+   */
+  public abstract Optional<String> externalId();
+
+  /**
+   * The SessionId for this Event.
+   */
+  public abstract Optional<String> sessionId();
+
+  /**
+   * The event type of this Event.
+   */
+  public abstract EventType type();
+
+  /**
+   * The event context of this Event.
+   */
+  public EventContext context() {
+    return EventContext.IOT;
+  }
+
+  /**
+   * The properties of this Event.
+   */
+  public abstract Map<String, Object> properties();
+
+  /**
+   * The context-specific properties of this Event.
+   */
+  @Override
+  public abstract IotContextInfo contextInfo();
+
+  /**
+   * The moment when this Event happened.
+   *
+   * <p>It defaults to "now()" if not specified when creating a new Event.</p>
+   */
+  @Value.Default
+  public OffsetDateTime date() {
+    return OffsetDateTime.now();
+  }
+
+  /**
+   * The moment when this Event was registered.
+   */
+  public abstract Optional<OffsetDateTime> registeredAt();
+}

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractLocalization.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractLocalization.java
@@ -1,0 +1,42 @@
+package it.contactlab.hub.sdk.java.models;
+
+import org.immutables.value.Value;
+
+/**
+ *  Localization.
+ */
+@Value.Immutable
+@Value.Style(typeImmutable = "*")
+public abstract class AbstractLocalization {
+
+  /**
+   * City.
+   */
+  public abstract String city();
+
+  /**
+   * Country.
+   */
+  public abstract String country();
+
+  /**
+   * Region.
+   */
+  public abstract String region();
+
+  /**
+   * Province.
+   */
+  public abstract String province();
+
+  /**
+   * Zip code.
+   */
+  public abstract String zip();
+
+  /**
+   * Geographical coordinates.
+   */
+  public abstract Geo geo();
+
+}

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractMobileContextInfo.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractMobileContextInfo.java
@@ -1,0 +1,26 @@
+package it.contactlab.hub.sdk.java.models;
+
+import org.immutables.value.Value;
+
+/**
+ * Context info about events made in mobile context.
+ */
+@Value.Immutable
+@Value.Style(typeImmutable = "*")
+public abstract class AbstractMobileContextInfo {
+
+  /**
+   * The client of this Event context info.
+   */
+  public abstract Client client();
+
+  /**
+   * The device of this Event context info.
+   */
+  public abstract Device device();
+
+  /**
+   * The user for this Event context info.
+   */
+  public abstract User user();
+}

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractMobileContextInfo.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractMobileContextInfo.java
@@ -7,20 +7,9 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @Value.Style(typeImmutable = "*")
-public abstract class AbstractMobileContextInfo {
-
-  /**
-   * The client of this Event context info.
-   */
-  public abstract Client client();
-
+public abstract class AbstractMobileContextInfo extends AbstractContextInfo{
   /**
    * The device of this Event context info.
    */
   public abstract Device device();
-
-  /**
-   * The user for this Event context info.
-   */
-  public abstract User user();
 }

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractMobileEvent.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractMobileEvent.java
@@ -1,0 +1,73 @@
+package it.contactlab.hub.sdk.java.models;
+
+import org.immutables.value.Value;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * An Event made in mobile context.
+ */
+@Value.Immutable
+@Value.Style(typeImmutable = "*")
+public abstract class AbstractMobileEvent extends AbstractEvent {
+
+  /**
+   * The ID of this Event.
+   */
+  public abstract Optional<String> id();
+
+  /**
+   * The CustomerId for this Event.
+   */
+  public abstract Optional<String> customerId();
+
+  /**
+   * The ExternalId for this Event.
+   */
+  public abstract Optional<String> externalId();
+
+  /**
+   * The SessionId for this Event.
+   */
+  public abstract Optional<String> sessionId();
+
+  /**
+   * The event type of this Event.
+   */
+  public abstract EventType type();
+
+  /**
+   * The event context of this Event.
+   */
+  public EventContext context() {
+    return EventContext.MOBILE;
+  }
+
+  /**
+   * The properties of this Event.
+   */
+  public abstract Map<String, Object> properties();
+
+  /**
+   * The context-specific properties of this Event.
+   */
+  @Override
+  public abstract MobileContextInfo contextInfo();
+
+  /**
+   * The moment when this Event happened.
+   *
+   * <p>It defaults to "now()" if not specified when creating a new Event.</p>
+   */
+  @Value.Default
+  public OffsetDateTime date() {
+    return OffsetDateTime.now();
+  }
+
+  /**
+   * The moment when this Event was registered.
+   */
+  public abstract Optional<OffsetDateTime> registeredAt();
+}

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractMobileEvent.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractMobileEvent.java
@@ -11,7 +11,7 @@ import java.util.Optional;
  */
 @Value.Immutable
 @Value.Style(typeImmutable = "*")
-public abstract class AbstractMobileEvent extends AbstractEvent {
+public abstract class AbstractMobileEvent extends Event {
 
   /**
    * The ID of this Event.
@@ -41,6 +41,7 @@ public abstract class AbstractMobileEvent extends AbstractEvent {
   /**
    * The event context of this Event.
    */
+  @Value.Derived
   public EventContext context() {
     return EventContext.MOBILE;
   }
@@ -54,7 +55,7 @@ public abstract class AbstractMobileEvent extends AbstractEvent {
    * The context-specific properties of this Event.
    */
   @Override
-  public abstract MobileContextInfo contextInfo();
+  public abstract Optional<MobileContextInfo> contextInfo();
 
   /**
    * The moment when this Event happened.

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractOtherContextInfo.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractOtherContextInfo.java
@@ -1,0 +1,21 @@
+package it.contactlab.hub.sdk.java.models;
+
+import org.immutables.value.Value;
+
+/**
+ * Context info about events made in other context.
+ */
+@Value.Immutable
+@Value.Style(typeImmutable = "*")
+public abstract class AbstractOtherContextInfo {
+
+  /**
+   * The client of this Event context info.
+   */
+  public abstract Client client();
+
+  /**
+   * The user for this Event context info.
+   */
+  public abstract User user();
+}

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractOtherContextInfo.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractOtherContextInfo.java
@@ -7,15 +7,5 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @Value.Style(typeImmutable = "*")
-public abstract class AbstractOtherContextInfo {
-
-  /**
-   * The client of this Event context info.
-   */
-  public abstract Client client();
-
-  /**
-   * The user for this Event context info.
-   */
-  public abstract User user();
+public abstract class AbstractOtherContextInfo extends AbstractContextInfo{
 }

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractOtherEvent.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractOtherEvent.java
@@ -1,0 +1,73 @@
+package it.contactlab.hub.sdk.java.models;
+
+import org.immutables.value.Value;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * An Event made in other context.
+ */
+@Value.Immutable
+@Value.Style(typeImmutable = "*")
+public abstract class AbstractOtherEvent extends AbstractEvent {
+
+  /**
+   * The ID of this Event.
+   */
+  public abstract Optional<String> id();
+
+  /**
+   * The CustomerId for this Event.
+   */
+  public abstract Optional<String> customerId();
+
+  /**
+   * The ExternalId for this Event.
+   */
+  public abstract Optional<String> externalId();
+
+  /**
+   * The SessionId for this Event.
+   */
+  public abstract Optional<String> sessionId();
+
+  /**
+   * The event type of this Event.
+   */
+  public abstract EventType type();
+
+  /**
+   * The event context of this Event.
+   */
+  public EventContext context() {
+    return EventContext.OTHER;
+  }
+
+  /**
+   * The properties of this Event.
+   */
+  public abstract Map<String, Object> properties();
+
+  /**
+   * The context-specific properties of this Event.
+   */
+  @Override
+  public abstract OtherContextInfo contextInfo();
+
+  /**
+   * The moment when this Event happened.
+   *
+   * <p>It defaults to "now()" if not specified when creating a new Event.</p>
+   */
+  @Value.Default
+  public OffsetDateTime date() {
+    return OffsetDateTime.now();
+  }
+
+  /**
+   * The moment when this Event was registered.
+   */
+  public abstract Optional<OffsetDateTime> registeredAt();
+}

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractOtherEvent.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractOtherEvent.java
@@ -11,7 +11,7 @@ import java.util.Optional;
  */
 @Value.Immutable
 @Value.Style(typeImmutable = "*")
-public abstract class AbstractOtherEvent extends AbstractEvent {
+public abstract class AbstractOtherEvent extends Event {
 
   /**
    * The ID of this Event.
@@ -41,6 +41,7 @@ public abstract class AbstractOtherEvent extends AbstractEvent {
   /**
    * The event context of this Event.
    */
+  @Value.Derived
   public EventContext context() {
     return EventContext.OTHER;
   }
@@ -54,7 +55,7 @@ public abstract class AbstractOtherEvent extends AbstractEvent {
    * The context-specific properties of this Event.
    */
   @Override
-  public abstract OtherContextInfo contextInfo();
+  public abstract Optional<OtherContextInfo> contextInfo();
 
   /**
    * The moment when this Event happened.

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractRetailContextInfo.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractRetailContextInfo.java
@@ -1,0 +1,33 @@
+package it.contactlab.hub.sdk.java.models;
+
+import org.immutables.value.Value;
+
+import java.util.Optional;
+
+/**
+ * Context info about events made in retail context.
+ */
+@Value.Immutable
+@Value.Style(typeImmutable = "*")
+public abstract class AbstractRetailContextInfo {
+
+  /**
+   * The sales assistant of this Event context info.
+   */
+  public abstract Optional<SalesAssistant> salesAssistant();
+
+  /**
+   * The client of this Event context info.
+   */
+  public abstract Client client();
+
+  /**
+   * The store of this Event context info.
+   */
+  public abstract Store store();
+
+  /**
+   * The user for this Event context info.
+   */
+  public abstract User user();
+}

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractRetailContextInfo.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractRetailContextInfo.java
@@ -9,25 +9,14 @@ import java.util.Optional;
  */
 @Value.Immutable
 @Value.Style(typeImmutable = "*")
-public abstract class AbstractRetailContextInfo {
+public abstract class AbstractRetailContextInfo extends AbstractContextInfo{
 
   /**
    * The sales assistant of this Event context info.
    */
   public abstract Optional<SalesAssistant> salesAssistant();
-
-  /**
-   * The client of this Event context info.
-   */
-  public abstract Client client();
-
   /**
    * The store of this Event context info.
    */
   public abstract Store store();
-
-  /**
-   * The user for this Event context info.
-   */
-  public abstract User user();
 }

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractRetailEvent.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractRetailEvent.java
@@ -11,7 +11,7 @@ import java.util.Optional;
  */
 @Value.Immutable
 @Value.Style(typeImmutable = "*")
-public abstract class AbstractRetailEvent extends AbstractEvent {
+public abstract class AbstractRetailEvent extends Event {
 
   /**
    * The ID of this Event.
@@ -41,6 +41,7 @@ public abstract class AbstractRetailEvent extends AbstractEvent {
   /**
    * The event context of this Event.
    */
+  @Value.Derived
   public EventContext context() {
     return EventContext.RETAIL;
   }
@@ -54,7 +55,7 @@ public abstract class AbstractRetailEvent extends AbstractEvent {
    * The context-specific properties of this Event.
    */
   @Override
-  public abstract RetailContextInfo contextInfo();
+  public abstract Optional<RetailContextInfo> contextInfo();
 
   /**
    * The moment when this Event happened.

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractRetailEvent.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractRetailEvent.java
@@ -1,0 +1,73 @@
+package it.contactlab.hub.sdk.java.models;
+
+import org.immutables.value.Value;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * An Event made in retail context.
+ */
+@Value.Immutable
+@Value.Style(typeImmutable = "*")
+public abstract class AbstractRetailEvent extends AbstractEvent {
+
+  /**
+   * The ID of this Event.
+   */
+  public abstract Optional<String> id();
+
+  /**
+   * The CustomerId for this Event.
+   */
+  public abstract Optional<String> customerId();
+
+  /**
+   * The ExternalId for this Event.
+   */
+  public abstract Optional<String> externalId();
+
+  /**
+   * The SessionId for this Event.
+   */
+  public abstract Optional<String> sessionId();
+
+  /**
+   * The event type of this Event.
+   */
+  public abstract EventType type();
+
+  /**
+   * The event context of this Event.
+   */
+  public EventContext context() {
+    return EventContext.RETAIL;
+  }
+
+  /**
+   * The properties of this Event.
+   */
+  public abstract Map<String, Object> properties();
+
+  /**
+   * The context-specific properties of this Event.
+   */
+  @Override
+  public abstract RetailContextInfo contextInfo();
+
+  /**
+   * The moment when this Event happened.
+   *
+   * <p>It defaults to "now()" if not specified when creating a new Event.</p>
+   */
+  @Value.Default
+  public OffsetDateTime date() {
+    return OffsetDateTime.now();
+  }
+
+  /**
+   * The moment when this Event was registered.
+   */
+  public abstract Optional<OffsetDateTime> registeredAt();
+}

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractSalesAssistant.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractSalesAssistant.java
@@ -1,0 +1,33 @@
+package it.contactlab.hub.sdk.java.models;
+
+import org.immutables.value.Value;
+
+import java.util.Optional;
+
+/**
+ *  Details about the sales assistant in an event context info.
+ */
+@Value.Immutable
+@Value.Style(typeImmutable = "*")
+public abstract class AbstractSalesAssistant {
+
+  /**
+   * The identifier of the user.
+   */
+  public abstract String id();
+
+  /**
+   * The first name of the user.
+   */
+  public abstract Optional<String> firstName();
+
+  /**
+   * The last name of the user.
+   */
+  public abstract Optional<String> lastName();
+
+  /**
+   * The contact information for the sales assistant.
+   */
+  public abstract Optional<UserContacts> contacts();
+}

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractSocialContextInfo.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractSocialContextInfo.java
@@ -7,15 +7,5 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @Value.Style(typeImmutable = "*")
-public abstract class AbstractSocialContextInfo {
-
-  /**
-   * The client of this Event context info.
-   */
-  public abstract Client client();
-
-  /**
-   * The user for this Event context info.
-   */
-  public abstract User user();
+public abstract class AbstractSocialContextInfo extends AbstractContextInfo{
 }

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractSocialContextInfo.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractSocialContextInfo.java
@@ -1,0 +1,21 @@
+package it.contactlab.hub.sdk.java.models;
+
+import org.immutables.value.Value;
+
+/**
+ * Context info about events made in social network context.
+ */
+@Value.Immutable
+@Value.Style(typeImmutable = "*")
+public abstract class AbstractSocialContextInfo {
+
+  /**
+   * The client of this Event context info.
+   */
+  public abstract Client client();
+
+  /**
+   * The user for this Event context info.
+   */
+  public abstract User user();
+}

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractSocialEvent.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractSocialEvent.java
@@ -11,7 +11,7 @@ import java.util.Optional;
  */
 @Value.Immutable
 @Value.Style(typeImmutable = "*")
-public abstract class AbstractSocialEvent extends AbstractEvent {
+public abstract class AbstractSocialEvent extends Event {
 
   /**
    * The ID of this Event.
@@ -41,6 +41,7 @@ public abstract class AbstractSocialEvent extends AbstractEvent {
   /**
    * The event context of this Event.
    */
+  @Value.Derived
   public EventContext context() {
     return EventContext.SOCIAL;
   }
@@ -54,7 +55,7 @@ public abstract class AbstractSocialEvent extends AbstractEvent {
    * The context-specific properties of this Event.
    */
   @Override
-  public abstract SocialContextInfo contextInfo();
+  public abstract Optional<SocialContextInfo> contextInfo();
 
   /**
    * The moment when this Event happened.

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractSocialEvent.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractSocialEvent.java
@@ -1,0 +1,73 @@
+package it.contactlab.hub.sdk.java.models;
+
+import org.immutables.value.Value;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * An Event made in social network context.
+ */
+@Value.Immutable
+@Value.Style(typeImmutable = "*")
+public abstract class AbstractSocialEvent extends AbstractEvent {
+
+  /**
+   * The ID of this Event.
+   */
+  public abstract Optional<String> id();
+
+  /**
+   * The CustomerId for this Event.
+   */
+  public abstract Optional<String> customerId();
+
+  /**
+   * The ExternalId for this Event.
+   */
+  public abstract Optional<String> externalId();
+
+  /**
+   * The SessionId for this Event.
+   */
+  public abstract Optional<String> sessionId();
+
+  /**
+   * The event type of this Event.
+   */
+  public abstract EventType type();
+
+  /**
+   * The event context of this Event.
+   */
+  public EventContext context() {
+    return EventContext.SOCIAL;
+  }
+
+  /**
+   * The properties of this Event.
+   */
+  public abstract Map<String, Object> properties();
+
+  /**
+   * The context-specific properties of this Event.
+   */
+  @Override
+  public abstract SocialContextInfo contextInfo();
+
+  /**
+   * The moment when this Event happened.
+   *
+   * <p>It defaults to "now()" if not specified when creating a new Event.</p>
+   */
+  @Value.Default
+  public OffsetDateTime date() {
+    return OffsetDateTime.now();
+  }
+
+  /**
+   * The moment when this Event was registered.
+   */
+  public abstract Optional<OffsetDateTime> registeredAt();
+}

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractStore.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractStore.java
@@ -1,0 +1,67 @@
+package it.contactlab.hub.sdk.java.models;
+
+import org.immutables.value.Value;
+
+/**
+ *  Store of the ecommerce context info.
+ */
+@Value.Immutable
+@Value.Style(typeImmutable = "*")
+public abstract class AbstractStore {
+
+  /**
+   * The identifier of the store.
+   */
+  public abstract String id();
+
+  /**
+   * The name of the store.
+   */
+  public abstract String name();
+
+  /**
+   * The type of the store.
+   */
+  public abstract StoreType type();
+
+  /**
+   * The street of the store.
+   */
+  public abstract String store();
+
+  /**
+   * The city of the store.
+   */
+  public abstract String city();
+
+  /**
+   * The country of the store.
+   */
+  public abstract String country();
+
+  /**
+   * The province of the store.
+   */
+  public abstract String province();
+
+  /**
+   * The region of the store.
+   */
+  public abstract String region();
+
+  /**
+   * The zip code of the store.
+   */
+  public abstract String zip();
+
+  /**
+   * The geographical coordinates of the store.
+   */
+  public abstract Geo geo();
+
+  /**
+   * The website of the store.
+   */
+  public abstract String website();
+
+}

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractUser.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractUser.java
@@ -1,0 +1,43 @@
+package it.contactlab.hub.sdk.java.models;
+
+import org.immutables.value.Value;
+
+import java.util.Optional;
+
+/**
+ *  Details about the user in an event context info.
+ */
+@Value.Immutable
+@Value.Style(typeImmutable = "*")
+public abstract class AbstractUser {
+
+  /**
+   * The identifier of the user.
+   */
+  public abstract String id();
+
+  /**
+   * The external identifier of the user.
+   */
+  public abstract Optional<String> externalId();
+
+  /**
+   * The username of the user.
+   */
+  public abstract Optional<String> username();
+
+  /**
+   * The first name of the user.
+   */
+  public abstract Optional<String> firstName();
+
+  /**
+   * The last name of the user.
+   */
+  public abstract Optional<String> lastName();
+
+  /**
+   * The contact information for the user.
+   */
+  public abstract Optional<UserContacts> contacts();
+}

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractUserContacts.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractUserContacts.java
@@ -1,0 +1,27 @@
+package it.contactlab.hub.sdk.java.models;
+
+import org.immutables.value.Value;
+
+import java.util.Optional;
+
+/**
+ *  The contact information for the user.
+ */
+@Value.Immutable
+@Value.Style(typeImmutable = "*")
+public abstract class AbstractUserContacts {
+  /**
+   * The email address of the user.
+   */
+  public abstract Optional<String> email();
+
+  /**
+   * The mobile phone number of the user.
+   */
+  public abstract Optional<String> mobilePhone();
+
+  /**
+   * The phone number of the user.
+   */
+  public abstract Optional<String> phone();
+}

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractWebContextInfo.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractWebContextInfo.java
@@ -7,15 +7,5 @@ import org.immutables.value.Value;
  */
 @Value.Immutable
 @Value.Style(typeImmutable = "*")
-public abstract class AbstractWebContextInfo {
-
-  /**
-   * The client of this Event context info.
-   */
-  public abstract Client client();
-
-  /**
-   * The user for this Event context info.
-   */
-  public abstract User user();
+public abstract class AbstractWebContextInfo extends AbstractContextInfo {
 }

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractWebContextInfo.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractWebContextInfo.java
@@ -1,0 +1,21 @@
+package it.contactlab.hub.sdk.java.models;
+
+import org.immutables.value.Value;
+
+/**
+ * Context info about events made in web context.
+ */
+@Value.Immutable
+@Value.Style(typeImmutable = "*")
+public abstract class AbstractWebContextInfo {
+
+  /**
+   * The client of this Event context info.
+   */
+  public abstract Client client();
+
+  /**
+   * The user for this Event context info.
+   */
+  public abstract User user();
+}

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractWebEvent.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractWebEvent.java
@@ -11,7 +11,7 @@ import java.util.Optional;
  */
 @Value.Immutable
 @Value.Style(typeImmutable = "*")
-public abstract class AbstractWebEvent extends AbstractEvent {
+public abstract class AbstractWebEvent extends Event {
 
   /**
    * The ID of this Event.
@@ -41,6 +41,7 @@ public abstract class AbstractWebEvent extends AbstractEvent {
   /**
    * The event context of this Event.
    */
+  @Value.Derived
   public EventContext context() {
     return EventContext.WEB;
   }
@@ -54,7 +55,7 @@ public abstract class AbstractWebEvent extends AbstractEvent {
    * The context-specific properties of this Event.
    */
   @Override
-  public abstract WebContextInfo contextInfo();
+  public abstract Optional<WebContextInfo> contextInfo();
 
   /**
    * The moment when this Event happened.

--- a/src/main/java/it/contactlab/hub/sdk/java/models/AbstractWebEvent.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/AbstractWebEvent.java
@@ -1,0 +1,73 @@
+package it.contactlab.hub.sdk.java.models;
+
+import org.immutables.value.Value;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * An Event made in web context.
+ */
+@Value.Immutable
+@Value.Style(typeImmutable = "*")
+public abstract class AbstractWebEvent extends AbstractEvent {
+
+  /**
+   * The ID of this Event.
+   */
+  public abstract Optional<String> id();
+
+  /**
+   * The CustomerId for this Event.
+   */
+  public abstract Optional<String> customerId();
+
+  /**
+   * The ExternalId for this Event.
+   */
+  public abstract Optional<String> externalId();
+
+  /**
+   * The SessionId for this Event.
+   */
+  public abstract Optional<String> sessionId();
+
+  /**
+   * The event type of this Event.
+   */
+  public abstract EventType type();
+
+  /**
+   * The event context of this Event.
+   */
+  public EventContext context() {
+    return EventContext.WEB;
+  }
+
+  /**
+   * The properties of this Event.
+   */
+  public abstract Map<String, Object> properties();
+
+  /**
+   * The context-specific properties of this Event.
+   */
+  @Override
+  public abstract WebContextInfo contextInfo();
+
+  /**
+   * The moment when this Event happened.
+   *
+   * <p>It defaults to "now()" if not specified when creating a new Event.</p>
+   */
+  @Value.Default
+  public OffsetDateTime date() {
+    return OffsetDateTime.now();
+  }
+
+  /**
+   * The moment when this Event was registered.
+   */
+  public abstract Optional<OffsetDateTime> registeredAt();
+}

--- a/src/main/java/it/contactlab/hub/sdk/java/models/Event.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/Event.java
@@ -9,9 +9,7 @@ import java.util.Optional;
 /**
  * An Event.
  */
-@Value.Immutable
-@Value.Style(typeImmutable = "*")
-public abstract class AbstractEvent {
+public abstract class Event {
 
   /**
    * The ID of this Event.
@@ -51,17 +49,13 @@ public abstract class AbstractEvent {
   /**
    * The context-specific properties of this Event.
    */
-  public abstract Map<String, Object> contextInfo();
+  public abstract Optional<? extends AbstractContextInfo> contextInfo();
 
   /**
    * The moment when this Event happened.
    *
-   * <p>It defaults to "now()" if not specified when creating a new Event.</p>
    */
-  @Value.Default
-  public OffsetDateTime date() {
-    return OffsetDateTime.now();
-  }
+  public abstract OffsetDateTime date();
 
   /**
    * The moment when this Event was registered.

--- a/src/main/java/it/contactlab/hub/sdk/java/models/Event.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/Event.java
@@ -1,13 +1,11 @@
 package it.contactlab.hub.sdk.java.models;
 
-import org.immutables.value.Value;
-
 import java.time.OffsetDateTime;
 import java.util.Map;
 import java.util.Optional;
 
 /**
- * An Event.
+ * An Event. Abstract class that is extended by Event subclasses.
  */
 public abstract class Event {
 

--- a/src/main/java/it/contactlab/hub/sdk/java/models/StoreType.java
+++ b/src/main/java/it/contactlab/hub/sdk/java/models/StoreType.java
@@ -1,0 +1,14 @@
+package it.contactlab.hub.sdk.java.models;
+
+public enum StoreType {
+  AIRPORT,
+  ECOMMERCE,
+  FLAGSHIP,
+  FREE_STANDING,
+  MALL,
+  OUTLET,
+  RESORT,
+  SIS,
+  WAREHOUSE,
+  NOT_DEFINED
+}

--- a/src/test/scala/integration/EventSpec.scala
+++ b/src/test/scala/integration/EventSpec.scala
@@ -48,7 +48,7 @@ class EventSpec extends FeatureSpec with GivenWhenThen {
         .build
 
       When("the user adds the event")
-      def create = ch.addEvent(event.asInstanceOf[Event])
+      def create = ch.addEvent(event)
 
       Then("the event is created successfully")
       noException should be thrownBy create
@@ -63,7 +63,7 @@ class EventSpec extends FeatureSpec with GivenWhenThen {
         .build
 
       When("the user adds the event")
-      def addEvent = Try(ch.addEvent(event.asInstanceOf[Event]))
+      def addEvent = Try(ch.addEvent(event))
 
       Then("the event is created successfully")
       addEvent should be a 'success
@@ -77,7 +77,7 @@ class EventSpec extends FeatureSpec with GivenWhenThen {
         .build
 
       When("the user adds the event")
-      def addEvent = Try(ch.addEvent(event.asInstanceOf[Event]))
+      def addEvent = Try(ch.addEvent(event))
 
       Then("the event is created successfully")
       addEvent should be a 'success
@@ -92,7 +92,7 @@ class EventSpec extends FeatureSpec with GivenWhenThen {
         .build
 
       When("the user adds the event")
-      def addEvent = Try(ch.addEvent(event.asInstanceOf[Event]))
+      def addEvent = Try(ch.addEvent(event))
 
       Then("the event is created successfully")
       addEvent should be a 'success

--- a/src/test/scala/integration/EventSpec.scala
+++ b/src/test/scala/integration/EventSpec.scala
@@ -14,9 +14,11 @@ import org.scalatest.FeatureSpec
 import org.scalatest.Inspectors._
 import org.scalatest.Matchers._
 import org.scalatest.GivenWhenThen
+import org.scalatest.TryValues._
 
 import scala.collection.JavaConversions._
 import scala.collection.mutable._
+import scala.util.Try
 
 class EventSpec extends FeatureSpec with GivenWhenThen {
 
@@ -36,10 +38,9 @@ class EventSpec extends FeatureSpec with GivenWhenThen {
   feature("adding a new event") {
     scenario("adding a simple event", Integration) {
       Given("a new event object")
-      val event = Event.builder
+      val event = WebEvent.builder
         .customerId(customerId)
         .`type`(EventType.viewedPage)
-        .context(EventContext.WEB)
         .properties(HashMap(
           "url" -> "https://example.com",
           "title" -> "Page Title"
@@ -47,7 +48,7 @@ class EventSpec extends FeatureSpec with GivenWhenThen {
         .build
 
       When("the user adds the event")
-      def create = ch.addEvent(event)
+      def create = ch.addEvent(event.asInstanceOf[Event])
 
       Then("the event is created successfully")
       noException should be thrownBy create
@@ -56,48 +57,45 @@ class EventSpec extends FeatureSpec with GivenWhenThen {
 
     scenario("adding an event with a sessionId", Integration) {
       Given("a new event object with a sessionId")
-      val event = Event.builder
+      val event = WebEvent.builder
         .sessionId("ses123")
         .`type`(EventType.viewedPage)
-        .context(EventContext.WEB)
         .build
 
       When("the user adds the event")
-      def addEvent = ch.addEvent(event)
+      def addEvent = Try(ch.addEvent(event.asInstanceOf[Event]))
 
       Then("the event is created successfully")
-      noException should be thrownBy addEvent
+      addEvent should be a 'success
     }
 
     scenario("adding an event with an externalId", Integration) {
       Given("a new event object with a externalId")
-      val event = Event.builder
+      val event = WebEvent.builder
         .externalId("ext123")
         .`type`(EventType.viewedPage)
-        .context(EventContext.WEB)
         .build
 
       When("the user adds the event")
-      def addEvent = ch.addEvent(event)
+      def addEvent = Try(ch.addEvent(event.asInstanceOf[Event]))
 
       Then("the event is created successfully")
-      noException should be thrownBy addEvent
+      addEvent should be a 'success
     }
 
     scenario("adding an event with sessionId and externalId", Integration) {
       Given("a new event object with both a sessionId and a externalId")
-      val event = Event.builder
+      val event = WebEvent.builder
         .sessionId("ses123")
         .externalId("ext123")
         .`type`(EventType.viewedPage)
-        .context(EventContext.WEB)
         .build
 
       When("the user adds the event")
-      def addEvent = ch.addEvent(event)
+      def addEvent = Try(ch.addEvent(event.asInstanceOf[Event]))
 
       Then("the event is created successfully")
-      noException should be thrownBy addEvent
+      addEvent should be a 'success
 
       And("the sessionId is ignored (externalId has precedence)")
       // FIXME: it's not trivial to test this condition
@@ -119,8 +117,7 @@ class EventSpec extends FeatureSpec with GivenWhenThen {
       event.context should be (EventContext.WEB)
       event.date should be (OffsetDateTime.parse("2016-12-29T14:36:49.339Z"))
       event.properties.get("title") should be("The Title")
-      event.contextInfo.get("client").asInstanceOf[java.util.Map[String,Object]]
-        .get("userAgent") should be ("testUserAgent")
+      event.contextInfo.get.client.userAgent.get should be ("testUserAgent")
       event.registeredAt.get shouldBe (OffsetDateTime.parse("2017-03-09T10:34:03.547Z"))
     }
 


### PR DESCRIPTION
Closes #90

Add new classes in `models` package in order to support the `contextInfo` schema with objects.

## Test Plan

Tests updated and reran successfully.
